### PR TITLE
Update Dockerfile.stretch-mono-v5.12.0.226

### DIFF
--- a/maven/Dockerfile.stretch-mono-v5.12.0.226
+++ b/maven/Dockerfile.stretch-mono-v5.12.0.226
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 
 RUN apt-get update
 RUN apt install -y apt-transport-https dirmngr librdkafka-dev librdkafka1 librdkafka++1
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN echo "deb https://download.mono-project.com/repo/debian stable-stretch main" | tee /etc/apt/sources.list.d/mono-official-stable.list \
   && apt-get update \
   && apt-get install -y apt-transport-https dirmngr mono-runtime binutils mono-devel ca-certificates-mono nuget \


### PR DESCRIPTION
Add `--no-tty` to `apt-key` otherwise gpg will complain about not having a tty available and stop when building the image.